### PR TITLE
Added support for syslog logging and the disabling of original Craft logging

### DIFF
--- a/LogHelperPlugin.php
+++ b/LogHelperPlugin.php
@@ -31,7 +31,7 @@ class LogHelperPlugin extends BasePlugin
      */
     public function getVersion()
     {
-        return '1.0.0';
+        return '2.0.0';
     }
 
     /**
@@ -59,10 +59,26 @@ class LogHelperPlugin extends BasePlugin
      */
     public function init()
     {
-        // Import log route
-        require_once __DIR__.'/logging/LogHelper_StdErrLogRoute.php';
+        // Disable web logging?
+        if (!craft()->config->get('useWebLog')) {
+            craft()->log->removeRoute('WebLogRoute');
+        }
 
-        // Add route
-        craft()->log->addRoute('Craft\LogHelper_StdErrLogRoute');
+        // Disable file logging?
+        if (!craft()->config->get('useFileLog')) {
+            craft()->log->removeRoute('FileLogRoute');
+        }
+
+        // Use STDERR logging?
+        if (craft()->config->get('useStdErrLog')) {
+            require_once __DIR__.'/logging/LogHelper_StdErrLogRoute.php';
+            craft()->log->addRoute('Craft\LogHelper_StdErrLogRoute');
+        }
+
+        // Use SysLog logging?
+        if (craft()->config->get('useSysLog')) {
+            require_once __DIR__.'/logging/LogHelper_SysLogRoute.php';
+            craft()->log->addRoute('Craft\LogHelper_SysLogRoute');
+        }
     }
 }

--- a/LogHelperPlugin.php
+++ b/LogHelperPlugin.php
@@ -69,6 +69,11 @@ class LogHelperPlugin extends BasePlugin
             craft()->log->removeRoute('FileLogRoute');
         }
 
+        // Disable profile logging?
+        if (!craft()->config->get('useProfileLog')) {
+            craft()->log->removeRoute('ProfileLogRoute');
+        }
+
         // Use STDERR logging?
         if (craft()->config->get('useStdErrLog')) {
             require_once __DIR__.'/logging/LogHelper_StdErrLogRoute.php';

--- a/config.php
+++ b/config.php
@@ -13,6 +13,7 @@
 return array(
     'useWebLog' => true,
     'useFileLog' => true,
+    'useProfileLog' => true,
     'useStdErrLog' => false,
     'useSysLog' => false,
 );

--- a/config.php
+++ b/config.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Log Helper Plugin.
+ *
+ * Advanced logging options
+ *
+ * @author    Nerds & Company
+ * @copyright Copyright (c) 2016, Nerds & Company
+ *
+ * @link      https://www.nerds.company
+ */
+return array(
+    'useWebLog' => true,
+    'useFileLog' => true,
+    'useStdErrLog' => false,
+    'useSysLog' => false,
+);

--- a/logging/LogHelper_StdErrLogRoute.php
+++ b/logging/LogHelper_StdErrLogRoute.php
@@ -24,7 +24,7 @@ class LogHelper_StdErrLogRoute extends \CLogRoute
         $strErr = fopen('php://stderr', 'w');
 
         foreach ($logs as $log) {
-            fwrite($strErr, $log[0]);
+            fwrite($strErr, $log[0]."\n");
         }
 
         fclose($strErr);

--- a/logging/LogHelper_SysLogRoute.php
+++ b/logging/LogHelper_SysLogRoute.php
@@ -22,7 +22,7 @@ class LogHelper_SysLogRoute extends \CLogRoute
     public function processLogs($logs)
     {
         foreach ($logs as $log) {
-            syslog(LOG_DEBUG, $log[0]);
+            syslog(LOG_DEBUG, $log[0]."\n");
         }
     }
 }

--- a/logging/LogHelper_SysLogRoute.php
+++ b/logging/LogHelper_SysLogRoute.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Craft;
+
+/**
+ * Log Helper Plugin.
+ *
+ * Advanced logging options
+ *
+ * @author    Nerds & Company
+ * @copyright Copyright (c) 2016, Nerds & Company
+ *
+ * @link      https://www.nerds.company
+ */
+class LogHelper_SysLogRoute extends \CLogRoute
+{
+    /**
+     * Process logs.
+     *
+     * @param array $logs
+     */
+    public function processLogs($logs)
+    {
+        foreach ($logs as $log) {
+            syslog(LOG_DEBUG, $log[0]);
+        }
+    }
+}


### PR DESCRIPTION
- Adds support for syslog logging, which is the default for Papertrail (non-Heroku)
- Adds the ability to remove web, file and profile logging
- Improves readability of the logs by appending newlines
