### PR TITLE
Use FileLogRoute

### DIFF
--- a/logging/LogHelper_BaseLogRoute.php
+++ b/logging/LogHelper_BaseLogRoute.php
@@ -12,33 +12,15 @@ namespace Craft;
  *
  * @link      https://www.nerds.company
  */
-abstract class LogHelper_BaseLogRoute extends \CLogRoute
+abstract class LogHelper_BaseLogRoute extends FileLogRoute
 {
-    // Public Methods
-    // =========================================================================
-
-    /**
-     * Initializes the log route. This method is invoked after the log route is created by the route manager.
-     *
-     * @return null
-     */
-    public function init()
-    {
-        $this->levels = craft()->config->get('devMode') ? '' : 'error,warning';
-        $this->filter = craft()->config->get('devMode') ? 'Craft\\LogFilter' : null;
-
-        parent::init();
-    }
-
-    // Protected Methods
-    // =========================================================================
 
     /**
      * Saves log messages in files.
      *
      * @param array $logs The list of log messages
      *
-     * @return null
+     * @return array
      */
     protected function processLogs($logs)
     {
@@ -51,26 +33,10 @@ abstract class LogHelper_BaseLogRoute extends \CLogRoute
             $time = $log[3];
             $force = (isset($log[4]) && $log[4] == true) ? true : false;
             $plugin = isset($log[5]) ? StringHelper::toLowerCase($log[5]) : 'craft';
-            
+
             $processed[] = $this->formatLogMessageWithForce($message, $level, $category, $time, $force, $plugin);
         }
-        
-        return $processed;
-    }
 
-    /**
-     * Formats a log message given different fields.
-     *
-     * @param string $message  The message content.
-     * @param int    $level    The message level.
-     * @param string $category The message category.
-     * @param int    $time     The message timestamp.
-     * @param bool   $force    Whether the message was forced or not.
-     *
-     * @return string The formatted message.
-     */
-    protected function formatLogMessageWithForce($message, $level, $category, $time, $force)
-    {
-        return "[$level] [$category]".($force ? " [Forced]" : "")." $message";
+        return $processed;
     }
 }

--- a/logging/LogHelper_StdErrLogRoute.php
+++ b/logging/LogHelper_StdErrLogRoute.php
@@ -22,7 +22,7 @@ class LogHelper_StdErrLogRoute extends LogHelper_BaseLogRoute
     protected function processLogs($logs)
     {
         $logs = parent::processLogs($logs);
-        
+
         $strErr = fopen('php://stderr', 'w');
 
         foreach ($logs as $log) {


### PR DESCRIPTION
Here's an tweaked alternative that extends Craft\FileLogRoute instead of copying `init` and `formatLogMessageWithForce`

Pros:
- less duplication from Craft
- log messages end up being identical

Cons:
- logs have a timestamp in the message, which is probably redundant when using syslog, etc.

I'm fine with either but this was my approach!